### PR TITLE
Fix spike writing

### DIFF
--- a/Source/RecordEngine/HDF5Recording.cpp
+++ b/Source/RecordEngine/HDF5Recording.cpp
@@ -97,6 +97,12 @@ void HDF5Recording::openFiles(File rootFolder, int experimentNumber, int recordi
     //KWX file
     spikesFile->initFile(basepath);
     spikesFile->open();
+    int nSpikes = getNumRecordedSpikes();
+    for (int i = 0; i < nSpikes; i++)
+    {
+         spikesFile->addChannelGroup(getSpikeChannel(i)->getNumChannels()); 
+    }
+
     spikesFile->startNewRecording(recordingNumber);
 
     //Let's just put the first processor (usually the source node) on the KWIK for now
@@ -272,7 +278,7 @@ void HDF5Recording::writeTimestampSyncText(uint16 sourceID, uint16 sourceIdx, in
 
 void HDF5Recording::addSpikeElectrode(int index, const SpikeChannel* elec)
 {
-    spikesFile->addChannelGroup(elec->getNumChannels());
+    //spikesFile->addChannelGroup(elec->getNumChannels()); // deprecated
 }
 void HDF5Recording::writeSpike(int electrodeIndex, const SpikeEvent* spike)
 {

--- a/Source/RecordEngine/KWIKFormat.cpp
+++ b/Source/RecordEngine/KWIKFormat.cpp
@@ -320,6 +320,7 @@ void KWXFile::initFile(String basename)
     if (isOpen()) return;
     filename = basename + ".kwx";
     readyToOpen=true;
+    numElectrodes = 0;
 }
 
 int KWXFile::createFileStructure()
@@ -338,7 +339,7 @@ int KWXFile::createFileStructure()
 void KWXFile::addChannelGroup(int nChannels)
 {
     channelArray.add(nChannels);
-    numElectrodes++;
+    createChannelGroup(numElectrodes++);
 }
 
 int KWXFile::createChannelGroup(int index)


### PR DESCRIPTION
This plugin no longer relies on the deprecated `addSpikeElectrode` method. The standard is to now add electrode groups in the `openFiles` method.