### PR TITLE
Prevent events from getting overwritten

### DIFF
--- a/Source/RecordEngine/KWIKFormat.cpp
+++ b/Source/RecordEngine/KWIKFormat.cpp
@@ -183,26 +183,28 @@ int KWEFile::createFileStructure()
     const uint16 ver = 2;
     if (createGroup("/recordings")) return -1;
     if (createGroup("/event_types")) return -1;
-    for (int i=0; i < eventNames.size(); i++)
+
+    for (int i = 0; i < eventNames.size(); i++)
     {
-        ScopedPointer<HDF5RecordingData> dSet;
+        std::cout << "Creating Group for events " << eventNames[i] << std::endl;
+
         String path = "/event_types/" + eventNames[i];
         if (createGroup(path)) return -1;
+        
         path += "/events";
         if (createGroup(path)) return -1;
-		dSet = createDataSet(BaseDataType::U64, 0, EVENT_CHUNK_SIZE, path + "/time_samples");
-        if (!dSet) return -1;
-		dSet = createDataSet(BaseDataType::U16, 0, EVENT_CHUNK_SIZE, path + "/recording");
-        if (!dSet) return -1;
+
+        timeStamps.add(createDataSet(BaseDataType::U64, 0, EVENT_CHUNK_SIZE, path + "/time_samples"));
+        recordings.add(createDataSet(BaseDataType::U16, 0, EVENT_CHUNK_SIZE, path + "/recording"));
+
         path += "/user_data";
         if (createGroup(path)) return -1;
-		dSet = createDataSet(BaseDataType::U8, 0, EVENT_CHUNK_SIZE, path + "/eventID");
-        if (!dSet) return -1;
-		dSet = createDataSet(BaseDataType::U8, 0, EVENT_CHUNK_SIZE, path + "/nodeID");
-        if (!dSet) return -1;
-        dSet = createDataSet(eventTypes[i],0,EVENT_CHUNK_SIZE,path + "/" + eventDataNames[i]);
-        if (!dSet) return -1;
+
+        eventID.add(createDataSet(BaseDataType::U8, 0, EVENT_CHUNK_SIZE, path + "/eventID"));
+        nodeID.add(createDataSet(BaseDataType::U8, 0, EVENT_CHUNK_SIZE, path + "/nodeID"));
+        eventData.add(createDataSet(eventTypes[i], 0, EVENT_CHUNK_SIZE,path + "/" + eventDataNames[i]));
     }
+
 	if (setAttribute(BaseDataType::U16, (void*)&ver, "/", "kwik_version")) return -1;
 
     return 0;
@@ -216,46 +218,13 @@ void KWEFile::startNewRecording(int recordingNumber, KWIKRecordingInfo* info)
     CHECK_ERROR(createGroup(recordPath));
     CHECK_ERROR(setAttributeStr(info->name,recordPath,String("name")));
 	CHECK_ERROR(setAttribute(BaseDataType::U64, &(info->start_time), recordPath, String("start_time")));
-    //	CHECK_ERROR(setAttribute(U32,&(info->start_sample),recordPath,String("start_sample")));
 	CHECK_ERROR(setAttribute(BaseDataType::F32, &(info->sample_rate), recordPath, String("sample_rate")));
 	CHECK_ERROR(setAttribute(BaseDataType::U32, &(info->bit_depth), recordPath, String("bit_depth")));
-   // CHECK_ERROR(createGroup(recordPath + "/raw"));
-  //  CHECK_ERROR(createGroup(recordPath + "/raw/hdf5_paths"));
-
-    for (int i = 0; i < eventNames.size(); i++)
-    {
-        HDF5RecordingData* dSet;
-        String path = "/event_types/" + eventNames[i] + "/events";
-        dSet = getDataSet(path + "/time_samples");
-        if (!dSet)
-            std::cerr << "Error loading event timestamps dataset for type " << i << std::endl;
-        timeStamps.add(dSet);
-        dSet = getDataSet(path + "/recording");
-        if (!dSet)
-            std::cerr << "Error loading event recordings dataset for type " << i << std::endl;
-        recordings.add(dSet);
-        dSet = getDataSet(path + "/user_data/eventID");
-        if (!dSet)
-            std::cerr << "Error loading event ID dataset for type " << i << std::endl;
-        eventID.add(dSet);
-        dSet = getDataSet(path + "/user_data/nodeID");
-        if (!dSet)
-            std::cerr << "Error loading event node ID dataset for type " << i << std::endl;
-        nodeID.add(dSet);
-        dSet = getDataSet(path + "/user_data/" + eventDataNames[i]);
-        if (!dSet)
-            std::cerr << "Error loading event channel dataset for type " << i << std::endl;
-        eventData.add(dSet);
-    }
 }
 
 void KWEFile::stopRecording()
 {
-    timeStamps.clear();
-    recordings.clear();
-    eventID.clear();
-    nodeID.clear();
-    eventData.clear();
+
 }
 
 void KWEFile::writeEvent(int type, uint8 id, uint8 processor, void* data, int64 timestamp)
@@ -272,17 +241,6 @@ void KWEFile::writeEvent(int type, uint8 id, uint8 processor, void* data, int64 
     CHECK_ERROR(eventData[type]->writeDataBlock(1,eventTypes[type],data));
 }
 
-/*void KWEFile::addKwdFile(String filename)
-{
-	if (kwdIndex == 0)
-	{
-		CHECK_ERROR(setAttributeStr(filename + "/recordings/" + String(recordingNumber), "/recordings/" + String(recordingNumber) +
-			"/raw", "hdf5_path"));
-	}
-    CHECK_ERROR(setAttributeStr(filename + "/recordings/" + String(recordingNumber),"/recordings/" + String(recordingNumber) +
-                                "/raw/hdf5_paths",String(kwdIndex)));
-    kwdIndex++;
-}*/
 
 void KWEFile::addEventType(String name, BaseDataType type, String dataName)
 {


### PR DESCRIPTION
If multiple recordings were stored in the same KWE file, the event datasets would get cleared each time a new recording started. Now, the events are appended instead.