### PR TITLE
Fix spike warnings

### DIFF
--- a/Source/RecordEngine/HDF5Recording.cpp
+++ b/Source/RecordEngine/HDF5Recording.cpp
@@ -92,16 +92,19 @@ void HDF5Recording::openFiles(File rootFolder, int experimentNumber, int recordi
     String basepath = rootFolder.getFullPathName() + rootFolder.separatorString + "experiment" + String(experimentNumber);
     //KWE file
     eventFile->initFile(basepath);
-    eventFile->open();
+    eventFile->open(); // calls createFileStructure
 
     //KWX file
     spikesFile->initFile(basepath);
-    spikesFile->open();
+    
     int nSpikes = getNumRecordedSpikes();
     for (int i = 0; i < nSpikes; i++)
     {
          spikesFile->addChannelGroup(getSpikeChannel(i)->getNumChannels()); 
     }
+
+    spikesFile->open(); // calls createFileStructure
+
 
     spikesFile->startNewRecording(recordingNumber);
 

--- a/Source/RecordEngine/KWIKFormat.cpp
+++ b/Source/RecordEngine/KWIKFormat.cpp
@@ -278,26 +278,33 @@ void KWXFile::initFile(String basename)
     if (isOpen()) return;
     filename = basename + ".kwx";
     readyToOpen=true;
+    channelArray.clear();
     numElectrodes = 0;
 }
 
 int KWXFile::createFileStructure()
 {
+    std::cout << "Creating file structure." << std::endl;
+
     const uint16 ver = 2;
     if (createGroup("/channel_groups")) return -1;
 	if (setAttribute(BaseDataType::U16, (void*)&ver, "/", "kwik_version")) return -1;
-    for (int i=0; i < channelArray.size(); i++)
+
+    for (int i = 0; i < channelArray.size(); i++)
     {
         int res = createChannelGroup(i);
         if (res) return -1;
     }
+
     return 0;
 }
 
 void KWXFile::addChannelGroup(int nChannels)
 {
+    std::cout << "Adding spike group with " << nChannels << " channels." << std::endl;
     channelArray.add(nChannels);
-    createChannelGroup(numElectrodes++);
+    numElectrodes++;
+    //createChannelGroup(numElectrodes++);
 }
 
 int KWXFile::createChannelGroup(int index)
@@ -321,7 +328,7 @@ void KWXFile::startNewRecording(int recordingNumber)
     String path;
     this->recordingNumber = recordingNumber;
 
-    for (int i=0; i < channelArray.size(); i++)
+    for (int i = 0; i < channelArray.size(); i++)
     {
         path = "/channel_groups/"+String(i);
         dSet=getDataSet(path+"/waveforms_filtered");
@@ -344,12 +351,14 @@ void KWXFile::stopRecording()
     spikeArray.clear();
     timeStamps.clear();
     recordingArray.clear();
+
 }
 
 void KWXFile::resetChannels()
 {
     stopRecording(); //Just in case
-    channelArray.clear();
+    
+    
 }
 
 void KWXFile::writeSpike(int groupIndex, int nSamples, const float* data, Array<float>& bitVolts, int64 timestamp)


### PR DESCRIPTION
When re-starting recording to the same file, extra spike channels were being appended, causing the HDF5 library to throw a warning when it couldn't access the DataSets for these channels. Saved data was not affected.